### PR TITLE
fix: add bounds check in CbtDataRead to prevent heap buffer overflow

### DIFF
--- a/lib/epson-cbt.c
+++ b/lib/epson-cbt.c
@@ -2793,6 +2793,8 @@ static EPS_INT16 CbtDataRead (
         if ( Cnt > 6 ) {
             Cnt -= 6;
             RBuff += 6;
+            if (ChPtr->ReadSize + Cnt > CBT_MAX_RTMP)
+                return EPCBT_ERR_PARAM;
             SBuff += ChPtr->ReadSize;
             for ( lp1 = 0; lp1 < Cnt; lp1++ )
                 *SBuff++ = *RBuff++;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  CbtDataRead() in lib/epson-cbt.c appends incoming printer data to a fixed 512-byte buffer (ReadBuff, allocated with CBT_MAX_RTMP) by advancing the write pointer by ChPtr->ReadSize (the cumulative offset) and  
  then copying Cnt bytes. There is no check that ReadSize + Cnt stays within CBT_MAX_RTMP. Repeated reads from a malicious or malfunctioning printer can cause a heap buffer overflow.                             
                                                                                                                                                                                                                   
  ## Fix                                                                                                                                                                                                           
                                                                                                                                                                                                                   
  Add a bounds check before the pointer advance: if ChPtr->ReadSize + Cnt exceeds CBT_MAX_RTMP, return EPCBT_ERR_PARAM immediately.                                                                                                                                   
                  
  ## Affected code                                                                                                                                                                                                 
                  
  lib/epson-cbt.c — CbtDataRead()