### PR TITLE
fix: remove signed cast on ParameterByte to prevent stack overflow

### DIFF
--- a/lib/epson-escpr-services.c
+++ b/lib/epson-escpr-services.c
@@ -456,7 +456,7 @@ EPS_ERR_CODE    serAnalyzeStatus (
     
         Header        = (EPS_UINT8) Field[0];
         ParameterByte = (EPS_UINT8) Field[1];
-        memcpy(Parameter, Field+2, (EPS_INT8)ParameterByte );
+        memcpy(Parameter, Field+2, Min(ParameterByte, sizeof(Parameter)));
         
         Field = Field + 2 + ParameterByte;
         


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  serAnalyzeStatus() in lib/epson-escpr-services.c casts the unsigned ParameterByte (uint8_t, range 0-255) to signed EPS_INT8 (int8_t, range -128..127) before passing it as the length argument to memcpy(). When 
  ParameterByte >= 0x80, the value becomes negative and is promoted to an extremely large size_t, causing memcpy() to overflow the 128-byte stack buffer and crash the process. A malicious printer can trigger    
  this by sending a status frame with ParameterByte set to 0x80 or higher.                                                                                                                                         
                                                                                                                                                                                                                   
  ## Fix                                                                                                                                                                                                           
                                                                                                                                                                                                                   
  Remove the (EPS_INT8) cast and use Min(ParameterByte, sizeof(Parameter)) to ensure the copy length never exceeds the destination buffer size. ParameterByte is already EPS_UINT8 (unsigned), so no sign          
  conversion occurs.

  ## Affected code                                                                                                                                                                                                 
                  
  lib/epson-escpr-services.c — serAnalyzeStatus()